### PR TITLE
Fix issue with file path parsing when the path of file doesn't have /

### DIFF
--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -55,7 +55,7 @@ module XCPretty
     # @regex Captured groups
     # $1 file_path
     # $2 file_name (e.g. KWNull.m)
-    COMPILE_MATCHER = /^Compile[\w]+\s.+?\s((?:\\.|[^ ])+\/((?:\\.|[^ ])+\.(?:m|mm|c|cc|cpp|cxx|swift)))\s.*/
+    COMPILE_MATCHER = /^Compile[\w]+\s.+?\s((?:(?:\\.|[^ ])+\/)*((?:\\.|[^ ])+\.(?:m|mm|c|cc|cpp|cxx|swift)))\s.*/
 
     # @regex Captured groups
     # $1 compiler_command


### PR DESCRIPTION
Example : 
CompileC build/bgtfsLib.build/Release-iphoneos/bgtfsLib.build/Objects-normal/armv7/Feed.o Feed.cpp normal armv7 c++ com.apple.compilers.llvm.clang.1_0.compiler